### PR TITLE
Make chatbot::query_chat compute intensive

### DIFF
--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn gen_random_number() -> usize {
 ///
 /// Warning: may take a few seconds!
 pub async fn query_chat(messages: &[String]) -> Vec<String> {
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    std::thread::sleep(Duration::from_secs(2));
     let most_recent = messages.last().unwrap();
     vec![
         format!("\"{most_recent}\"? And how does that make you feel?"),

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use miniserve::{http::StatusCode, Content, Request, Response};
 use serde::{Deserialize, Serialize};
 use tokio::join;
@@ -12,29 +14,33 @@ async fn index(_req: Request) -> Response {
     Ok(Content::Html(content))
 }
 
-async fn generate_response(messages: &[String]) -> String {
-    let query = chatbot::query_chat(messages);
-    let rand_n = chatbot::gen_random_number();
-    let (resp_vec, rand_result) = join!(query, rand_n);
-    resp_vec[rand_result % resp_vec.len()].clone()
+async fn generate_chat_from_body(body: &str) -> Result<Chat, Response> {
+    let mut chat: Chat = serde_json::from_str(body).map_err(|_| Err(StatusCode::BAD_REQUEST))?;
+    let messages = Arc::new(chat.messages);
+    let messages_ref = Arc::clone(&messages);
+    let query = tokio::spawn(async move { chatbot::query_chat(&messages_ref).await });
+
+    let (query_result, i) = join!(query, chatbot::gen_random_number());
+
+    let mut resp_vec = query_result.map_err(|_| Err(StatusCode::INTERNAL_SERVER_ERROR))?;
+    let resp = resp_vec.remove(i % resp_vec.len());
+    chat.messages = Arc::into_inner(messages).unwrap();
+    chat.messages.push(resp);
+
+    Ok(chat)
 }
 
 async fn post_chat(req: Request) -> Response {
-    match req {
-        Request::Post(body) => {
-            let mut chat: Chat =
-                serde_json::from_str(&body).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let Request::Post(body) = req else {
+        return Err(StatusCode::METHOD_NOT_ALLOWED);
+    };
 
-            let resp = generate_response(&chat.messages).await;
-            chat.messages.push(resp);
+    let chat = generate_chat_from_body(&body)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let chat_str = serde_json::to_string(&chat).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-            let chat_str =
-                serde_json::to_string(&chat).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-            Ok(Content::Json(chat_str))
-        }
-        _ => Err(StatusCode::BAD_REQUEST),
-    }
+    Ok(Content::Json(chat_str))
 }
 
 #[tokio::main]


### PR DESCRIPTION
"Improvements" to our "language model" have required it to become more computationally intensive. This is represented by `tokio::time::sleep` (a non-blocking operation) changing into `std::thread::sleep` (a blocking operation).