### PR TITLE
Add new Chatbot data structure

### DIFF
--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -20,27 +20,30 @@ pub async fn gen_random_number() -> usize {
 
 /// A chatbot that responds to inputs.
 pub struct Chatbot {
-    emoji: String,
+    emojis: Vec<String>,
+    emoji_counter: usize,
 }
 
 impl Chatbot {
     /// Creates a new chatbot that uses the provided emoji in its responses.
-    pub fn new(emoji: String) -> Self {
-        Chatbot { emoji }
+    pub fn new(emojis: Vec<String>) -> Self {
+        Chatbot {
+            emojis,
+            emoji_counter: 0,
+        }
     }
 
     /// Generates a list of possible responses given the current chat.
     ///
     /// Warning: may take a few seconds!
-    pub async fn query_chat(&self, messages: &[String]) -> Vec<String> {
+    pub async fn query_chat(&mut self, messages: &[String]) -> Vec<String> {
         std::thread::sleep(Duration::from_secs(2));
         let most_recent = messages.last().unwrap();
+        let emoji = &self.emojis[self.emoji_counter];
+        self.emoji_counter = (self.emoji_counter + 1) % self.emojis.len();
         vec![
-            format!(
-                "\"{most_recent}\"? And how does that make you feel? {}",
-                self.emoji
-            ),
-            format!("\"{most_recent}\"! Interesting! Go on... {}", self.emoji),
+            format!("\"{most_recent}\"? And how does that make you feel? {emoji}",),
+            format!("\"{most_recent}\"! Interesting! Go on... {emoji}"),
         ]
     }
 }

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -18,14 +18,29 @@ pub async fn gen_random_number() -> usize {
     RNG.with(|rng| rng.borrow_mut().gen())
 }
 
-/// Generates a list of possible responses given the current chat.
-///
-/// Warning: may take a few seconds!
-pub async fn query_chat(messages: &[String]) -> Vec<String> {
-    std::thread::sleep(Duration::from_secs(2));
-    let most_recent = messages.last().unwrap();
-    vec![
-        format!("\"{most_recent}\"? And how does that make you feel?"),
-        format!("\"{most_recent}\"! Interesting! Go on..."),
-    ]
+/// A chatbot that responds to inputs.
+pub struct Chatbot {
+    emoji: String,
+}
+
+impl Chatbot {
+    /// Creates a new chatbot that uses the provided emoji in its responses.
+    pub fn new(emoji: String) -> Self {
+        Chatbot { emoji }
+    }
+
+    /// Generates a list of possible responses given the current chat.
+    ///
+    /// Warning: may take a few seconds!
+    pub async fn query_chat(&self, messages: &[String]) -> Vec<String> {
+        std::thread::sleep(Duration::from_secs(2));
+        let most_recent = messages.last().unwrap();
+        vec![
+            format!(
+                "\"{most_recent}\"? And how does that make you feel? {}",
+                self.emoji
+            ),
+            format!("\"{most_recent}\"! Interesting! Go on... {}", self.emoji),
+        ]
+    }
 }

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -19,6 +19,7 @@ pub async fn gen_random_number() -> usize {
 }
 
 /// A chatbot that responds to inputs.
+#[derive(Debug)]
 pub struct Chatbot {
     emojis: Vec<String>,
     emoji_counter: usize,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,8 +1,10 @@
-use std::sync::Arc;
-
 use miniserve::{http::StatusCode, Content, Request, Response};
 use serde::{Deserialize, Serialize};
-use tokio::join;
+use std::sync::{Arc, LazyLock};
+use tokio::{
+    join,
+    sync::{mpsc, oneshot},
+};
 
 #[derive(Serialize, Deserialize)]
 struct Chat {
@@ -14,20 +16,23 @@ async fn index(_req: Request) -> Response {
     Ok(Content::Html(content))
 }
 
-async fn generate_chat_from_body(body: &str) -> Result<Chat, Response> {
-    let mut chat: Chat = serde_json::from_str(body).map_err(|_| Err(StatusCode::BAD_REQUEST))?;
-    let messages = Arc::new(chat.messages);
-    let messages_ref = Arc::clone(&messages);
-    let query = tokio::spawn(async move { chatbot::query_chat(&messages_ref).await });
+async fn query_chat(messages: &Arc<Vec<String>>) -> Vec<String> {
+    type Payload = (Arc<Vec<String>>, oneshot::Sender<Vec<String>>);
+    static SENDER: LazyLock<mpsc::Sender<Payload>> = LazyLock::new(|| {
+        let (tx, mut rx) = mpsc::channel::<Payload>(1024);
+        tokio::spawn(async move {
+            let mut chatbot = chatbot::Chatbot::new(vec![":-)".into(), "^^".into()]);
+            while let Some((messages, responder)) = rx.recv().await {
+                let response = chatbot.query_chat(&messages).await;
+                responder.send(response).unwrap();
+            }
+        });
+        tx
+    });
 
-    let (query_result, i) = join!(query, chatbot::gen_random_number());
-
-    let mut resp_vec = query_result.map_err(|_| Err(StatusCode::INTERNAL_SERVER_ERROR))?;
-    let resp = resp_vec.remove(i % resp_vec.len());
-    chat.messages = Arc::into_inner(messages).unwrap();
-    chat.messages.push(resp);
-
-    Ok(chat)
+    let (tx, rx) = oneshot::channel();
+    SENDER.send((Arc::clone(messages), tx)).await.unwrap();
+    rx.await.unwrap()
 }
 
 async fn post_chat(req: Request) -> Response {
@@ -35,9 +40,15 @@ async fn post_chat(req: Request) -> Response {
         return Err(StatusCode::METHOD_NOT_ALLOWED);
     };
 
-    let chat = generate_chat_from_body(&body)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let mut chat: Chat = serde_json::from_str(&body).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let messages = Arc::new(chat.messages);
+    let (i, mut responses) = join!(chatbot::gen_random_number(), query_chat(&messages));
+
+    let response = responses.remove(i % responses.len());
+    chat.messages = Arc::into_inner(messages).unwrap();
+    chat.messages.push(response);
+
     let chat_str = serde_json::to_string(&chat).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(Content::Json(chat_str))


### PR DESCRIPTION
Refactors `chatbot::query_chat` into a method on the `Chatbot` data structure. This causes the build to break for the `server` crate. The main changes are:
* `Chatbot::new` takes as input a vector of emojis, which the chatbot will include to improve the attitude of users.
* `Chatbot::query_chat` is stateful because it rotates through emojis to keep the chat fresh.