### PR TITLE
Make chatbot functions take a variable length of time

### DIFF
--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -14,7 +14,8 @@ pub fn seed_rng(seed: u64) {
 ///
 /// Warning: may take a few seconds!
 pub async fn gen_random_number() -> usize {
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    let sleep_time = RNG.with(|rng| rng.borrow_mut().gen_range::<f32, _>(0. ..5.));
+    tokio::time::sleep(Duration::from_secs_f32(sleep_time)).await;
     RNG.with(|rng| rng.borrow_mut().gen())
 }
 
@@ -45,8 +46,9 @@ impl Chatbot {
     ///
     /// Warning: may take a few seconds!
     pub async fn query_chat(&mut self, messages: &[String], docs: &[String]) -> Vec<String> {
-        tokio::time::sleep(Duration::from_secs(2)).await;
         let most_recent = messages.last().unwrap();
+        let sleep_time = RNG.with(|rng| rng.borrow_mut().gen_range::<f32, _>(0. ..5.));
+        tokio::time::sleep(Duration::from_secs_f32(sleep_time)).await;
         let emoji = &self.emojis[self.emoji_counter];
         self.emoji_counter = (self.emoji_counter + 1) % self.emojis.len();
         vec![

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -2,7 +2,9 @@ use miniserve::{http::StatusCode, Content, Request, Response};
 use serde::{Deserialize, Serialize};
 use std::{
     path::PathBuf,
+    pin::pin,
     sync::{Arc, LazyLock},
+    time::{Duration, Instant},
 };
 use tokio::{
     fs, join,
@@ -50,14 +52,25 @@ fn chatbot_thread() -> (mpsc::Sender<Payload>, mpsc::Sender<()>) {
             let paths = chatbot.retrieval_documents(&messages);
             let docs = load_docs(paths).await;
 
-            let chat_fut = chatbot.query_chat(&messages, &docs);
-            let cancel_fut = cancel_rx.recv();
-            tokio::select! {
-                response = chat_fut => {
-                    responder.send(Some(response)).unwrap();
-                },
-                _ = cancel_fut => {
-                    responder.send(None).unwrap();
+            let mut chat_fut = pin!(chatbot.query_chat(&messages, &docs));
+
+            let mut cancel_fut = pin!(cancel_rx.recv());
+            let start = Instant::now();
+
+            loop {
+                let log_fut = tokio::time::sleep(Duration::from_secs(1));
+                tokio::select! {
+                    response = &mut chat_fut => {
+                        responder.send(Some(response)).unwrap();
+                        break;
+                    },
+                    _ = &mut cancel_fut => {
+                        responder.send(None).unwrap();
+                        break;
+                    },
+                    _ = log_fut => {
+                        println!("Waiting for {} seconds", start.elapsed().as_secs());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Both `gen_random_number` and `query_chat` now take between 0 and 5 seconds to execute.